### PR TITLE
feat: automatically purge adm data after days

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Configuration is done using environment variables or `dotenv`. See `.env.example
 - `DISCORD_CHANNEL` - the channel name bot should listen too, if this is empty the bot will listen to all channels.
 - `DISCORD_APP_ID` - the bot application ID
 - `ALLIANCE_ID` - the alliance ID for collecting ADM values, only systems owned by this alliance will be collected.
+- `DB_KEEP_ADM_DAYS` - how many days adm history should be kept in database (default 7).
 
 ## 🔍 Caveats
 * The ADM data from ESI is only updated once a day, so refreshing more often than that is not necessary.

--- a/pydisadm/__main__.py
+++ b/pydisadm/__main__.py
@@ -35,8 +35,9 @@ def main() -> int:
     update_static_data(database)
 
     controller = AdmController(configuration, database)
+    
     controller.update_adm_data()
-    controller.purge_adm_records(5)
+    controller.purge_adm_records(configuration.db_keep_adm_days)
 
     bot = AdmBot(configuration, controller)
     bot.setup_cogs()

--- a/pydisadm/__main__.py
+++ b/pydisadm/__main__.py
@@ -36,6 +36,7 @@ def main() -> int:
 
     controller = AdmController(configuration, database)
     controller.update_adm_data()
+    controller.purge_adm_records(5)
 
     bot = AdmBot(configuration, controller)
     bot.setup_cogs()

--- a/pydisadm/configuration.py
+++ b/pydisadm/configuration.py
@@ -10,13 +10,31 @@ class Configuration:
 
         alliance_id = os.getenv('ALLIANCE_ID')
 
+        db_keep_adm_days = os.getenv('DB_KEEP_ADM_DAYS', '7')
+        if db_keep_adm_days is not None:
+            try:
+                db_keep_adm_days = int(db_keep_adm_days)
+            except ValueError as error:
+                raise ValueError(
+                    '[configuration] invalid `DB_KEEP_ADM_DAYS` value',
+                    db_keep_adm_days) from error
+
+        self.db_keep_adm_days = db_keep_adm_days
+
         if alliance_id is not None:
             try:
                 alliance_id = int(alliance_id)
             except ValueError as error:
-                raise ValueError('[configuration] invalid `ALLIANCE_ID` value', alliance_id) from error
+                raise ValueError(
+                    '[configuration] invalid `ALLIANCE_ID` value',
+                    alliance_id) from error
 
         self.alliance_id = alliance_id
 
     def __str__(self):
-        return f'{self.__class__.__name__}(discord_token={self.discord_token}, discord_channel={self.discord_channel}, discord_app_id={self.discord_app_id}, alliance_id={self.alliance_id})'
+        return (f'{self.__class__.__name__}' +
+            f'(discord_token={self.discord_token}, ' +
+            f'discord_channel={self.discord_channel}, ' +
+            f'discord_app_id={self.discord_app_id}, ' +
+            f'alliance_id={self.alliance_id} ' +
+            f'db_keep_adm_days={self.db_keep_adm_days})')

--- a/pydisadm/controller/adm_controller.py
+++ b/pydisadm/controller/adm_controller.py
@@ -205,6 +205,11 @@ class AdmController:
 
         self.database.insert_systems(system_adms)
 
+    def purge_adm_records(self, days_old: int):
+        """Purge adm records more than days_old days old"""
+
+        self.database.delete_system_rows(days_old)
+
     def write_file(self, file_name, content) -> bool:
         """Write content to file"""
         with open(file_name, 'w', encoding='UTF-8') as file:

--- a/pydisadm/runnable/runnable_refresh.py
+++ b/pydisadm/runnable/runnable_refresh.py
@@ -29,6 +29,10 @@ def refresh_job(controller: AdmController):
     controller.update_adm_data()
     logger.info('adm data update finished')
 
+    logger.info('purge old adm data...')
+    controller.purge_adm_records(7)
+    logger.info('purge finished')
+
 def run_auto_refresh(interrupt_event):
     """Run automatic adm data refresh in separate thread"""
     logger.info('starting adm data update thread')

--- a/pydisadm/runnable/runnable_refresh.py
+++ b/pydisadm/runnable/runnable_refresh.py
@@ -16,21 +16,21 @@ def scheduler_loop(interrupt_event):
 
     controller = AdmController(configuration, database)
 
-    schedule.every().day.at('11:30', tz='UTC').do(refresh_job, controller)
+    schedule.every().day.at('11:30', tz='UTC').do(refresh_job, controller, configuration)
 
     while True:
         schedule.run_pending()
         if interrupt_event.wait(timeout=1000):
             break
 
-def refresh_job(controller: AdmController):
+def refresh_job(controller: AdmController, configuration: Configuration):
     """Refresh adm data"""
     logger.info('updating adm data...')
     controller.update_adm_data()
     logger.info('adm data update finished')
 
     logger.info('purge old adm data...')
-    controller.purge_adm_records(7)
+    controller.purge_adm_records(configuration.db_keep_adm_days)
     logger.info('purge finished')
 
 def run_auto_refresh(interrupt_event):

--- a/pydisadm/services/database.py
+++ b/pydisadm/services/database.py
@@ -80,3 +80,15 @@ class Database:
             INNER JOIN map ON map.solarSystemID = systems.system_id
             WHERE map.solarSystemName=? ORDER BY created_at DESC LIMIT ?
         """, self.conn, params=[system, limit])
+
+    def delete_system_rows(self, days_old):
+        """Delete system rows older than days_old"""
+        cur = self.conn.cursor()
+        cur.execute(f"""
+            DELETE FROM systems 
+            WHERE id IN (
+                SELECT id FROM systems WHERE created_at < (select datetime('now', '-{days_old} day'))
+            )
+        """)
+
+        self.conn.commit()


### PR DESCRIPTION
Added feature automatically purging ADM data from database when it's old. The maximum age can be configured in days using variable `DB_KEEP_ADM_DAYS`. If the variable is not configured it will default to `7`.

resolves #4 